### PR TITLE
[FEAT] AppColorSet 추가

### DIFF
--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Accent/Blue.colorset/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Accent/Blue.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x7A",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Accent/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Accent/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Accent/Red.colorset/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Accent/Red.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x55",
+          "green" : "0x2D",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Accent/Yellow.colorset/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Accent/Yellow.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xCC",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Font/Body.colorset/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Font/Body.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x43",
+          "green" : "0x43",
+          "red" : "0x43"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Font/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Font/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Font/SubTitle.colorset/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Font/SubTitle.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2F",
+          "green" : "0x2F",
+          "red" : "0x2F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Font/Title.colorset/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Font/Title.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x20",
+          "green" : "0x20",
+          "red" : "0x20"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Font/WhiteSubTitle.colorset/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Font/WhiteSubTitle.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF7",
+          "green" : "0xF7",
+          "red" : "0xF7"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Primary/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Primary/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Primary/Disable.colorset/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Primary/Disable.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD2",
+          "green" : "0xCE",
+          "red" : "0xCB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Primary/Primary1.colorset/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Primary/Primary1.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x3B",
+          "green" : "0x33",
+          "red" : "0x2E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Primary/Primary2.colorset/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Primary/Primary2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x55",
+          "green" : "0x4D",
+          "red" : "0x49"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Primary/Primary3.colorset/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Primary/Primary3.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x83",
+          "green" : "0x79",
+          "red" : "0x72"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Primary/Primary4.colorset/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Primary/Primary4.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCF",
+          "green" : "0xC0",
+          "red" : "0xB7"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Primary/White.colorset/Contents.json
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Resources/Assets/Colors.xcassets/Primary/White.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Sources/AutoGenerated/Assets.swift
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Sources/AutoGenerated/Assets.swift
@@ -25,7 +25,20 @@ internal typealias AssetImageTypeAlias = ImageAsset.Image
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
 internal enum Gen {
   internal enum Colors {
+    internal static let blue = ColorAsset(name: "Blue")
+    internal static let red = ColorAsset(name: "Red")
+    internal static let yellow = ColorAsset(name: "Yellow")
     internal static let dim = ColorAsset(name: "Dim")
+    internal static let body = ColorAsset(name: "Body")
+    internal static let subTitle = ColorAsset(name: "SubTitle")
+    internal static let title = ColorAsset(name: "Title")
+    internal static let whiteSubTitle = ColorAsset(name: "WhiteSubTitle")
+    internal static let disable = ColorAsset(name: "Disable")
+    internal static let primary1 = ColorAsset(name: "Primary1")
+    internal static let primary2 = ColorAsset(name: "Primary2")
+    internal static let primary3 = ColorAsset(name: "Primary3")
+    internal static let primary4 = ColorAsset(name: "Primary4")
+    internal static let white = ColorAsset(name: "White")
   }
   internal enum Images {
     internal static let launchScreenMap = ImageAsset(name: "launchScreenMap")

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Sources/DesignSystem/AppColor.swift
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Sources/DesignSystem/AppColor.swift
@@ -1,0 +1,46 @@
+//
+//  AppColor.swift
+//  SaveEarth
+//
+
+import SwiftUI
+
+extension DesignSystem {
+  enum AppColor {
+
+    // MARK: - Accent Color
+
+    /// #007AFF
+    static let appBlue: Color = Gen.Colors.blue.swiftUIColor
+    /// #FF2D55
+    static let appRed: Color = Gen.Colors.red.swiftUIColor
+    /// #FFCC00
+    static let appYellow: Color = Gen.Colors.yellow.swiftUIColor
+
+    // MARK: - Font Color
+
+    /// #434343
+    static let appBody: Color = Gen.Colors.body.swiftUIColor
+    /// #202020
+    static let appTitle: Color = Gen.Colors.title.swiftUIColor
+    /// #2F2F2F
+    static let appSubTitle: Color = Gen.Colors.subTitle.swiftUIColor
+    /// #F7F7F7
+    static let appWhiteSubTitle: Color = Gen.Colors.whiteSubTitle.swiftUIColor
+
+    // MARK: - Primary Color
+
+    /// #2E333B
+    static let appPrimary1: Color = Gen.Colors.primary1.swiftUIColor
+    /// #494D55
+    static let appPrimary2: Color = Gen.Colors.primary2.swiftUIColor
+    /// #727983
+    static let appPrimary3: Color = Gen.Colors.primary3.swiftUIColor
+    /// #B7C0CF
+    static let appPrimary4: Color = Gen.Colors.primary4.swiftUIColor
+    /// #FFFFFF
+    static let appWhite: Color = Gen.Colors.white.swiftUIColor
+    /// #CBCED2
+    static let appDisable: Color = Gen.Colors.disable.swiftUIColor
+  }
+}

--- a/SaveEarth/Projects/SaveEarth/SaveEarth/Sources/DesignSystem/DesignSystem.swift
+++ b/SaveEarth/Projects/SaveEarth/SaveEarth/Sources/DesignSystem/DesignSystem.swift
@@ -1,0 +1,6 @@
+//
+//  DesignSystem.swift
+//  SaveEarth
+//
+
+enum DesignSystem { }


### PR DESCRIPTION
## 변경 사항 설명
<!-- 이 PR에서 변경한 내용을 간단히 설명해주세요. -->
<!-- 버그 픽스인 경우, 해당 이슈 내용을 간단히 설명해주세요. -->

피그마에 정의된 컬러 적용 및 `DesignSystem.AppColor` 추가

## 변경된 사항을 작성 해주세요
<!-- 주요 변경 사항들에 대해 파일, 함수, 변수 등을 작성 해주세요. -->

- `DesignSystem` enum 정의
- DesignSystem 내, `AppColor` enum 정의
  - Swift Gen 기반 적용
- AppColor Resources 적용
  - AccentColor
    -  appBlue: #007AFF
    -  appRed: #FF2D55
    -  appYellow: #FFCC00
  - Font Color
    -  appBody: #434343
    -  appTitle: #202020
    -  appSubTitle: #2F2F2F
    -  appWhiteSubTitle: #F7F7F7
  - Primary Color
    -  appPrimary1: #2E333B
    -  appPrimary2: #494D55
    -  appPrimary3: #727983
    -  appPrimary4: #B7C0CF
    -  appWhite: #FFFFFF
    -  appDisable: #CBCED2

## 변경 유형
<!-- 해당하는 항목에 x 표시를 해주세요. -->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 코드 스타일 업데이트 (포맷팅, 변수명 등)
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 내용 변경
- [ ] 기타 (설명해주세요): 

## 체크리스트
<!-- 완료한 항목에 x 표시를 해주세요. -->
- [ ] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [ ] 변경 사항에 대한 테스트를 추가했습니다.
- [ ] 모든 새로운 기능과 변경 사항이 문서화되었습니다.
- [ ] PR이 적절한 크기로 나누어졌습니다.

## 스크린샷 (UI 변경이 있는 경우)
<!-- UI 변경이 있다면 스크린샷을 추가해주세요. -->
<img width="227" alt="Screenshot of Figma at Aug 1, 2024 at 12_55_08 AM" src="https://github.com/user-attachments/assets/f2263e16-66af-4a53-b18d-9c1b45a83569">



## 추가 정보
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요. -->
